### PR TITLE
Enable Setup for GHC 8.2.2

### DIFF
--- a/patience.cabal
+++ b/patience.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 2.0
 name:
   patience
 version:

--- a/patience.cabal
+++ b/patience.cabal
@@ -4,7 +4,7 @@ name:
 version:
   0.2.0.0
 license:
-  BSD-3-Clause
+  BSD3
 license-file:
   LICENSE
 synopsis:


### PR DESCRIPTION
The Cabal library version for GHC 8.2.2 is Cabal 2.0, which causes the following:

    $ ghc --version
    The Glorious Glasgow Haskell Compilation System, version 8.2.2
    $ ghc -o Setup Setup.hs
    $ ./Setup configure
    Configuring patience-0.2.0.0...
    Setup: This package description follows version 2.2 of the Cabal
    specification. This tool only supports up to version 2.0.1.0.

This isn't seen when using a separate cabal-install package at version 2.2 or later, but the Setup build process is still a valid process and used by some configurations (e.g. nix: https://nixos.org).

The cabal file does not contain any post-2.0 features (and could actually specify a cabal-version of 1.10 and still work), so dropping the minimum cabal version allows the Setup-based build under GHC 8.2.